### PR TITLE
Let the user decide if the buffers images should be refreshed after every insertion

### DIFF
--- a/README.org
+++ b/README.org
@@ -14,7 +14,8 @@
 
   Features:
   - The link to the image file will be placed at /point./
-  - /org inline images/ can be automatically refreshed to display it immediately.
+  - /org inline images/ can be automatically refreshed to display the
+    imeage immediately.
   - Screenshots are placed into the org entry's attachment
     directory.
   - If no attachment directory has been defined, the user will be

--- a/README.org
+++ b/README.org
@@ -15,7 +15,7 @@
   Features:
   - The link to the image file will be placed at /point./
   - /org inline images/ can be automatically refreshed to display the
-    imeage immediately.
+    image immediately.
   - Screenshots are placed into the org entry's attachment
     directory.
   - If no attachment directory has been defined, the user will be
@@ -70,7 +70,7 @@
   inline images will be automatically refreshed to display every
   inserted image immediately. Set this to nil if you prefere to manually
   refresh inline images. In this case you will just see the link
-  to the image file after calling `org-attach-screenshot'.
+  to the image file after calling =org-attach-screenshot=.
 
 * Usage
   While in an org mode buffer, use the *org-attach-screenshot* command to take a screenshot and

--- a/README.org
+++ b/README.org
@@ -13,8 +13,8 @@
   /org-attach-screenshot/.
 
   Features:
-  - The link to the image file will be placed at /point/
-  - /org inline images/ will be turned on to display it.
+  - The link to the image file will be placed at /point./
+  - /org inline images/ can be automatically refreshed to display it immediately.
   - Screenshots are placed into the org entry's attachment
     directory.
   - If no attachment directory has been defined, the user will be
@@ -38,7 +38,7 @@
   by configuring the =org-attach-screenshot-command-line= variable.
 
   #+BEGIN_SRC emacs-lisp
-    (setq org-attach-screenshot-command-line "mycommand -x -y -z %f")    
+    (setq org-attach-screenshot-command-line "mycommand -x -y -z %f")
   #+END_SRC
 
   By default the =import= command from the ImageMagick suite is used, i.e.
@@ -53,10 +53,10 @@
 
   #+BEGIN_SRC emacs-lisp
   (setq org-attach-screenshot-dirfunction
-		(lambda () 
-		  (progn (assert (buffer-file-name))
-			 (concat (file-name-sans-extension (buffer-file-name))
-				 "_att"))))
+        (lambda ()
+          (progn (assert (buffer-file-name))
+             (concat (file-name-sans-extension (buffer-file-name))
+                 "_att"))))
   #+END_SRC
 
   If =org-attach-screenshot-relative-links= is set to =t= the filename references
@@ -64,6 +64,12 @@
   default, since normally you want to be able to move the document together with
   its attachment directory. If you set this option to =nil= absolute path names
   will be used.
+
+  If =org-attach-screenshot-auto-refresh= is set to non-nil the buffers
+  inline images will be automatically refreshed to display every
+  inserted image immediately. Set this to nil if you prefere to manually
+  refresh inline images. In this case you will just see the link
+  to the image file after calling `org-attach-screenshot'.
 
 * Usage
   While in an org mode buffer, use the *org-attach-screenshot* command to take a screenshot and
@@ -102,4 +108,3 @@
   to rather make it independent instead of forcing users to install both.
   I wanted to have an especially well integrated screenshot feature to
   match the org workflow.
-

--- a/org-attach-screenshot.el
+++ b/org-attach-screenshot.el
@@ -71,6 +71,16 @@ always be relative filenames.  If nil, the links will just be the
 concatenation of the attachment dir and the filename"
   :type 'boolean :group 'org-attach-screenshot)
 
+(defcustom org-attach-screenshot-auto-refresh t
+  "Refresh inline image display after inserting an image.
+Set this to non-nil if you want to see the new image immediately
+after calling `org-attach-screenshot'. Set this to nil if you
+prefere to manually refresh inline image display. In this case
+you will just see the link to the image file after calling
+`org-attach-screenshot'."
+  :type 'boolean :group 'org-attach-screenshot)
+
+
 ;;;###autoload
 (defun org-attach-screenshot (prfx filename)
   "Take an area screenshot and place it in the entry's attachment directory.
@@ -138,7 +148,8 @@ the links being already placed inside the text."
 	  (error "screenshot command exited with status %d: %s" status
 		 (mapconcat 'identity (cons cmd args) " ")) )
 	(message "wrote screenshot to %s" scrpath))
-      (org-display-inline-images nil t))))
+      (when org-attach-screenshot-auto-refresh
+        (org-display-inline-images nil t)))))
 
 (defun org-attach-screenshot-get-attach-dir ()
   "Return or create the current entry's attachment directory.


### PR DESCRIPTION
I added a variable to disable the refresh of inline images at the end of `org-attach-screenshot`. Screenshots tend to be very large. If they get displayed automatically, they I often loose track of where my point is after the insertion. Sometimes I would prefere to be able to insert multiple sreenshots in a row an then toggle inline image display to see if all images are ok.